### PR TITLE
Percentage coverage at user configurable depth

### DIFF
--- a/bin/report.py
+++ b/bin/report.py
@@ -47,6 +47,10 @@ def main():
     parser.add_argument(
         "--max_len", default=700, type=int,
         help="Maximum read length")
+    parser.add_argument(
+        "--report_depth", default=100, type=int,
+        help="Depth at which to provide a coverage statistics, e.g. 76% of genome covered at `report_depth`"
+    )
     args = parser.parse_args()
 
     report_doc = report.HTMLReport(
@@ -170,7 +174,7 @@ comparing depth across samples.***
     plots_pool = list()
     plots_orient = list()
     plots_combined = list()
-    depth_lim = 100
+    depth_lim = args.report_depth
     for sample in sorted(df['sample_name'].unique()):
         bc = df['sample_name'] == sample
         depth = df[bc].groupby('pos').sum().reset_index()

--- a/main.nf
+++ b/main.nf
@@ -19,6 +19,7 @@ Options:
     --medaka_model      STR     Medaka model name (default: $params.medaka_model)
     --min_len           INT     Minimum read length (default: set by scheme)
     --max_len           INT     Maximum read length (default: set by scheme)
+    --report_depth      INT     Min. depth for percentage coverage (default: $params.report_depth)
     --scheme_version    STR     Primer scheme ($valid_schemes)
                                 indicating correspondence between
                                 barcodes and sample names. (default: $params.scheme_version)
@@ -111,8 +112,8 @@ process report {
         file "wf-artic-report.html"
     """
     report.py nextclade.json consensus_status.txt wf-artic-report.html \
-        --min_len $params._min_len --max_len $params._max_len \
-        --depths depth_stats/* --summaries read_stats/* \
+        --min_len $params._min_len --max_len $params._max_len --report_depth \
+        $params.report_depth --depths depth_stats/* --summaries read_stats/* \
         --bcftools_stats vcf_stats/*
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,6 +16,7 @@ params {
     samples = null
     min_len = null
     max_len = null
+    report_depth = 100
     medaka_model = "r941_min_high_g360"
     scheme_name = "SARS-CoV-2"
     scheme_version = "V3"


### PR DESCRIPTION
PHE are asking for percentage coverage at 30x. I thought it would be useful to be able to configure the depth from the default 100x so the report reflects this. 

