### PR TITLE
Parameterise previously hardcoded depth of coverage ceiling

### DIFF
--- a/bin/run_artic.sh
+++ b/bin/run_artic.sh
@@ -9,6 +9,7 @@ medaka_model=$5
 full_scheme_name=$6
 threads=$7
 max_softclip_length=$8
+normalise=$9
 
 function mock_artic {
     # write an empty VCF
@@ -38,7 +39,7 @@ artic guppyplex --skip-quality-check \
 # the output of the above will be...
 READFILE="${sample_name}_${sample_name}.fastq"
 
-artic minion --medaka --normalise 200 --threads ${threads} \
+artic minion --medaka --normalise ${normalise} --threads ${threads} \
     --read-file ${READFILE} \
     --medaka-model ${medaka_model} \
     --scheme-directory primer_schemes \

--- a/main.nf
+++ b/main.nf
@@ -79,7 +79,7 @@ process runArtic {
     run_artic.sh \
         ${sample_id} ${directory} ${params._min_len} ${params._max_len} \
         ${params.medaka_model} ${params.full_scheme_name} \
-        ${task.cpus} ${params._max_softclip_length}
+        ${task.cpus} ${params._max_softclip_length} ${params.normalise}
     bcftools stats ${sample_id}.pass.named.vcf.gz > ${sample_id}.pass.named.stats 
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,7 @@ params {
     min_len = null
     max_len = null
     max_softclip_length = null
+    normalise = 200
     report_depth = 100
     medaka_model = "r941_prom_variant_g360"
     scheme_name = "SARS-CoV-2"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -107,6 +107,10 @@
                     "type": "integer",
                     "description": "Remove reads with alignments showing large softclipping"
                 },
+                "normalise": {
+                    "type": "integer",
+                    "description": "Depth ceiling for depth of coverage normalisation"
+                },
                 "medaka_model": {
                     "type": "string",
                     "default": "r941_prom_variant_g360",


### PR DESCRIPTION
Introduces optional `--normalise {integer}` parameter addressing https://github.com/epi2me-labs/wf-artic/issues/15

Defaults to 200, the previously hardcoded value.

I previously PRed with other stuff as part of a messy branch. This should be easy to merge.

Tested working with and without optional `--normalise` parameters.