### PR TITLE
Enable overwrite of reports as required from nf v22.10.0

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -148,17 +148,21 @@ profiles {
 
 timeline {
   enabled = true
+  overwrite = true
   file = "${params.out_dir}/execution/timeline.html"
 }
 report {
   enabled = true
+  overwrite = true
   file = "${params.out_dir}/execution/report.html"
 }
 trace {
   enabled = true
+  overwrite = true
   file = "${params.out_dir}/execution/trace.txt"
 }
 dag {
   enabled = true
+  overwrite = true
   file = "${params.out_dir}/execution/pipeline.svg"
 }


### PR DESCRIPTION
Resolves #71 

If one wanted to introduce rolling report numbers - that would be possible, but as it stands the behaviour is not good at all as it causes tedious work on behalf of the user and this change should be made deliberately.

For context:
https://bioinformatics.stackexchange.com/a/20097/12272

>Rotation of report files (trace, execution, timeline etc) was removed recently (since version 22.10.0 in a762ed5). >To overwrite the existing trace file you will need to add the following to your Nextflow config: `trace.overwrite = true`
>See: https://github.com/nextflow-io/nextflow/issues/3317