### PR TITLE
Add artic minion logging for debugging 

### DIFF
--- a/bin/run_artic.sh
+++ b/bin/run_artic.sh
@@ -53,7 +53,7 @@ artic minion --medaka --normalise ${normalise} --threads ${threads} \
     --scheme-directory ${scheme_dir} \
     --scheme-version ${scheme_version} \
     --max-softclip-length ${max_softclip_length} \
-    ${scheme_name} ${sample_name} \
+    ${scheme_name} ${sample_name} &> ${sample_name}.artic.log.txt \
     || mock_artic
 
 for vcf_set in "pass" "merged.gvcf"; do


### PR DESCRIPTION
I've had a few issues with the `artic minion` command in the `run_artic.sh`. One issue is the `mock_artic`  bash function essentially acts as a silencer if the artic minion pipeline fails. Unfortunately, if there's an issue this makes debugging impossible. See for example my other issue #104

